### PR TITLE
Remove dependencies on focus, firstSC and scValidator preprocessors

### DIFF
--- a/common/src/main/java/com/amazon/corretto/arctic/common/repository/impl/TestRepositoryImpl.java
+++ b/common/src/main/java/com/amazon/corretto/arctic/common/repository/impl/TestRepositoryImpl.java
@@ -18,6 +18,7 @@ package com.amazon.corretto.arctic.common.repository.impl;
 
 import java.awt.image.BufferedImage;
 import java.nio.file.Path;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Stream;
 import javax.inject.Inject;
@@ -137,6 +138,7 @@ public final class TestRepositoryImpl implements TestRepository {
 
         final ScreenshotCheck sc = Stream.concat(Stream.of(test.get().getInitialSc()),
                         test.get().getScreenChecks().stream())
+                .filter(Objects::nonNull)
                 .filter(it -> it.getFilename().equals(scPath))
                 .findAny().orElse(null);
 

--- a/player/src/main/java/com/amazon/corretto/arctic/player/postprocessing/impl/RecordingMigrator.java
+++ b/player/src/main/java/com/amazon/corretto/arctic/player/postprocessing/impl/RecordingMigrator.java
@@ -17,6 +17,7 @@
 package com.amazon.corretto.arctic.player.postprocessing.impl;
 
 import java.nio.file.Path;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Stream;
 import javax.inject.Inject;
@@ -65,6 +66,7 @@ public final class RecordingMigrator implements ArcticPlayerPostProcessor {
             ArcticTest recording = test.getRecording();
             repository.removeTestCase(recording.getTestId(), recording.getScope());
             Stream.concat(Stream.of(recording.getInitialSc()), recording.getScreenChecks().stream())
+                    .filter(Objects::nonNull)
                     .filter(it -> it.getImage() != null)
                     .forEach(it -> {
                         it.getAlternativeImages().clear();

--- a/player/src/main/java/com/amazon/corretto/arctic/player/postprocessing/impl/TestAutoUpdater.java
+++ b/player/src/main/java/com/amazon/corretto/arctic/player/postprocessing/impl/TestAutoUpdater.java
@@ -17,6 +17,7 @@
 package com.amazon.corretto.arctic.player.postprocessing.impl;
 
 import java.nio.file.Path;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Stream;
 import javax.inject.Inject;
@@ -58,6 +59,7 @@ public final class TestAutoUpdater implements ArcticPlayerPostProcessor {
         if (autoSave) {
             ArcticTest recording = test.getRecording();
             Stream.concat(Stream.of(recording.getInitialSc()), recording.getScreenChecks().stream())
+                    .filter(Objects::nonNull)
                     .filter(it -> it.getImage() != null)
                     .forEach(it -> repository.saveImage(recording.getTestName(), recording.getTestCase(),
                             recording.getScope(), getScName(it.getFilename()), it.getImage()));

--- a/player/src/main/java/com/amazon/corretto/arctic/player/preprocessing/impl/ScreenCheckValidatorPreProcessor.java
+++ b/player/src/main/java/com/amazon/corretto/arctic/player/preprocessing/impl/ScreenCheckValidatorPreProcessor.java
@@ -87,18 +87,22 @@ public final class ScreenCheckValidatorPreProcessor implements ArcticPlayerPrePr
     @Override
     public boolean preProcess(final ArcticRunningTest test) {
         log.debug("Checking if we match test {}:{}", test.getRecording().getTestName(), test.getRecording().getTestCase());
-        wbManager.position(test.getRecording().getInitialSc().getWorkbench());
-        shadeManager.position(test.getRecording().getInitialSc().getShades());
-        timeController.waitFor(focusWait);
-        focusManager.giveFocus(test.getRecording().getFocusPoint());
-        timeController.waitFor(focusWait);
-        final ScreenshotCheck sc = screenRecorder.capture(test.getRecording().getInitialSc().getSa());
-        final boolean result = imageComparator.compare(sc, test.getRecording().getInitialSc(), test.getTestId(),
-                test.getRecording().getScope());
-        if (!result && bypass) {
-            log.warn("Bypassing first sc");
+        if (test.getRecording().getInitialSc() != null) {
+            wbManager.position(test.getRecording().getInitialSc().getWorkbench());
+            shadeManager.position(test.getRecording().getInitialSc().getShades());
+            timeController.waitFor(focusWait);
+            focusManager.giveFocus(test.getRecording().getFocusPoint());
+            timeController.waitFor(focusWait);
+            final ScreenshotCheck sc = screenRecorder.capture(test.getRecording().getInitialSc().getSa());
+            final boolean result = imageComparator.compare(sc, test.getRecording().getInitialSc(), test.getTestId(),
+                    test.getRecording().getScope());
+            if (!result && bypass) {
+                log.warn("Bypassing first sc");
+            }
+
+            return result || bypass;
         }
-        return result || bypass;
+        return true;
     }
 
     @Override

--- a/player/src/main/resources/player.properties
+++ b/player/src/main/resources/player.properties
@@ -189,7 +189,7 @@ arctic.player.time.controller = advanced
 # truncations: Manipulates the list of events, so we ignore a certain set of mouse and keyboard events from the beginning
 #   or end of the test. This is used to account for recording issues adding extra events.
 # timeControl: Signals the timeController to start the clock for the replay.
-arctic.player.pre.processors = cleanUp, firstTestDelay, overrides, testDelay, scValidator, eventsLoader, truncations, timeControl
+arctic.player.pre.processors = cleanUp, firstTestDelay, overrides, testDelay, eventsLoader, truncations, timeControl
 
 # The first test on a test group can take significantly more than other tests to run. We have an extra wait timer for
 # that case. Whenever we get a signal that a test group has finished, we will consider the next test to require the

--- a/recorder/src/main/java/com/amazon/corretto/arctic/recorder/postprocessing/impl/ScreenCheckHashPostProcessor.java
+++ b/recorder/src/main/java/com/amazon/corretto/arctic/recorder/postprocessing/impl/ScreenCheckHashPostProcessor.java
@@ -45,7 +45,7 @@ public final class ScreenCheckHashPostProcessor implements ArcticRecorderPostPro
 
     @Override
     public boolean postProcess(final ArcticTest test) {
-        postProcess(test.getInitialSc());
+        if (test.getInitialSc() != null) postProcess(test.getInitialSc());
         test.getScreenChecks().forEach(this::postProcess);
         return true;
     }

--- a/recorder/src/main/java/com/amazon/corretto/arctic/recorder/postprocessing/impl/ScreenCheckSavePostProcessor.java
+++ b/recorder/src/main/java/com/amazon/corretto/arctic/recorder/postprocessing/impl/ScreenCheckSavePostProcessor.java
@@ -48,7 +48,8 @@ public final class ScreenCheckSavePostProcessor implements ArcticRecorderPostPro
 
     @Override
     public boolean postProcess(final ArcticTest test) {
-        postProcess(test.getInitialSc(), test.getTestName(), test.getTestCase(), test.getScope(), String.valueOf(0));
+        if (test.getInitialSc() != null)
+            postProcess(test.getInitialSc(), test.getTestName(), test.getTestCase(), test.getScope(), String.valueOf(0));
         int scCount = 1;
         for (final ScreenshotCheck sc : test.getScreenChecks()) {
             postProcess(sc, test.getTestName(), test.getTestCase(), test.getScope(), String.valueOf(scCount));

--- a/recorder/src/main/resources/recorder.properties
+++ b/recorder/src/main/resources/recorder.properties
@@ -164,7 +164,7 @@ arctic.recorder.post.save.eventsFile = Events.json
 #   init: performs the initialization of basic fields for the test.
 #   focus: issues an awt event to give the test window focus and saves it.
 #   firstSc: saves a firstScreenshotCheck of the test
-arctic.recorder.pre.enabled = init, focus, firstSc
+arctic.recorder.pre.enabled = init
 
 # Defines which events we mark by default as the preferred playback. Check ArcticEvent.java for values.
 arctic.recorder.pre.init.preferredPlayMode = 0x13E06


### PR DESCRIPTION
### Motivation and context
Arctic includes some preprocessors that attempt to normalize how tests are in the screen to capture the titlebar. This is legacy code when test identification was done by comparing this first screenshot, but it is no longer needed and brings more issues than advantages. I removed them as the default and adapt some code that expected this first screenshot to always be present

### How has this been tested?
Tested by performing some test recordings and replays for jtreg tests

