### PR TITLE
Update some default values

### DIFF
--- a/player/src/main/resources/player.properties
+++ b/player/src/main/resources/player.properties
@@ -15,7 +15,7 @@
 #
 
 # Defines where the test suite we run is located
-arctic.common.repository.json.path = ../arctic_tests
+arctic.common.repository.json.path = ./tests
 
 # Name we used to save the test definition.
 arctic.common.repository.json.file = Test.json
@@ -88,7 +88,7 @@ arctic.common.screen.capture.margin.y = 0
 arctic.player.confirmation.mode = true
 
 # In playback mode, the backend will reproduce the full set of events, even if a failed check is found.
-arctic.player.fast.mode = false
+arctic.player.fast.mode = true
 
 # Defines which engines will process the events of the recording. Possible values are:
 # awtMouse: Reproduce mouse movement/click using AWT Robot
@@ -151,7 +151,7 @@ arctic.player.backend.sc.pixel.hint.fast = false
 arctic.player.backend.sc.pixel.hint.mask = true
 
 # Minimum % of pixels that need to be a perfect match
-arctic.player.backend.sc.pixel.confidence.min = 0.95
+arctic.player.backend.sc.pixel.confidence.min = 0.65
 
 # Check pixels that are hidden by shades
 arctic.player.backend.sc.pixel.checkShades = false

--- a/recorder/src/main/resources/recorder.properties
+++ b/recorder/src/main/resources/recorder.properties
@@ -15,7 +15,7 @@
 #
 
 # Defines where the test suite we run is located
-arctic.common.repository.json.path = ../arctic_tests
+arctic.common.repository.json.path = ./tests
 
 # Name we used to save the test definition.
 arctic.common.repository.json.file = Test.json
@@ -127,7 +127,7 @@ arctic.recorder.control.jnh.spawnShadeKeyCode = 46
 arctic.recorder.control.jnh.discardKeyCode = 47
 
 # Keycode we will check to start a recording
-arctic.recorder.control.jnh.modifiers = 29, 56
+arctic.recorder.control.jnh.modifiers = 42, 56
 
 # List with all the post processors we want to enable. Recommended to keep default values.
 # Values are:


### PR DESCRIPTION
### Description

Changed the repository folder to `./tests`
Fast mode is now default
Changed recording modifier keys

### Motivation and context
Set some new default values for commonly selected options

### How has this been tested?
Recorded and replayed jtreg tests on mac

### Platform information
    Works on OS: [e.g. Amazon Linux 2 only]
    Applies to version [e.g. "0.4.12" (output from "java -jar Arctic.jar -v")]


### Additional context



### Contribution confirmation

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

