### PR TITLE
Rename jars

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -25,7 +25,7 @@ If applicable, add screenshots to help explain your problem.
 
 ### Platform information
     OS: [e.g. Amazon Linux 2]
-    Version [e.g. "0.4.12" (output from "java -jar Arctic.jar -v")]
+    Version [e.g. "0.4.12" (output from "java -jar arctic-<VERSION>.jar -v")]
 
 ### Additional context
 Add any other context about the problem here.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,7 +18,7 @@ Instead, report the problem by email to aws-security@amazon.com.
 
 ### Platform information
     Works on OS: [e.g. Amazon Linux 2 only]
-    Applies to version [e.g. "0.4.12" (output from "java -jar Arctic.jar -v")]
+    Applies to version [e.g. "0.4.12" (output from "java -jar arctic-<VERSION>.jar -v")]
 
 
 ### Additional context

--- a/README.md
+++ b/README.md
@@ -37,11 +37,11 @@ As **Arctic** relies on pixel comparison to validate the different results, chan
 
 Because **Arctic** captures all keyboard and mouse events, during the recording we need a way to tell **Arctic** what we want it to do without interfering with the test. This can be done by pressing specific key combination. When several modifier keys are pressed (such as **ctrl** or **alt**) **Arctic** will interpret the next key presses as instructions. Among others, these instructions can be to start or stop the recording or to capture a screenshot.
 
-The keys are configured in the **recorder.properties** file with properties that start with **arctic.recorder.control.jnh**. The correspondence between keycodes and keys can be checked by running ```java -jar Arctic.jar -k```. This command will print the keycode of the different keys as they are pressed. By default, **ctrl+alt+z** is used to start/stop the recording and **ctrl+alt+x** is used to capture a screenshot.
+The keys are configured in the **recorder.properties** file with properties that start with **arctic.recorder.control.jnh**. The correspondence between keycodes and keys can be checked by running ```java -jar arctic-<VERSION>.jar -k```. This command will print the keycode of the different keys as they are pressed. By default, **ctrl+alt+z** is used to start/stop the recording and **ctrl+alt+x** is used to capture a screenshot.
 
 ### Record a test
 
-Before running a test, start **Arctic** in recording mode by executing ```java -jar Arctic.jar -r```.
+Before running a test, start **Arctic** in recording mode by executing ```java -jar arctic-<VERSION>.jar -r```.
 
 ![Workbench](images/workbench.png)
 
@@ -49,7 +49,7 @@ Once you see the *Workbench* and *Shade windows*, you can start running a test c
 
 Additionally, we need to tell **Arctic** which test is on the screen. Arctic identifies tests with two strings, the **testName** and the **testCase**. We can do this by writing test run **<testName> <testCase>** in the arctic command line.
 
-**Arctic** can also receive this information via RMI. This requires setting the configuration key **arctic.common.cmd.rmi.enabled** from **false** to either **local_only** or **true**. Once this is done, we can send this information through a second arctic instance, running ```java -jar Arctic.jar -c test run <testName> <testCase>``` or by implementing a custom application that uses the RMI interface present in **ArcticShared.jar**
+**Arctic** can also receive this information via RMI. This requires setting the configuration key **arctic.common.cmd.rmi.enabled** from **false** to either **local_only** or **true**. Once this is done, we can send this information through a second arctic instance, running ```java -jar arctic-<VERSION>.jar -c test run <testName> <testCase>``` or by implementing a custom application that uses the RMI interface present in **ArcticShared.jar**
 
 ![simplebuttontest](images/simplebuttontest.png)
 
@@ -73,18 +73,18 @@ Screenshots and recordings will be saved in the **arctic_tests** folder. This ca
 
 ### Replay a test
 
-Once the recording is finished, **Arctic** is ready to replay the test. Launch **Arctic** in player mode with ```java -jar Arctic.jar -p```.
+Once the recording is finished, **Arctic** is ready to replay the test. Launch **Arctic** in player mode with ```java -jar arctic-<VERSION>.jar -p```.
 
-Once **Arctic** has loaded, start the relevant test and then instruct **Arctic** to run it with ```java -jar Arctic.jar -c test run <testName> <testCase>```. **Arctic** will reproduce the keyboard and mouse events and capture screenshots at the same time as in the recording.
+Once **Arctic** has loaded, start the relevant test and then instruct **Arctic** to run it with ```java -jar arctic-<VERSION>.jar -c test run <testName> <testCase>```. **Arctic** will reproduce the keyboard and mouse events and capture screenshots at the same time as in the recording.
 
 <video src="https://github.com/user-attachments/assets/ae7f6bd1-5c18-4bff-8e30-ce118c6150fb" controls="controls" style="max-width: 730px;">
 </video>
 
-Once the test is finished, we can pass this information to **Arctic** with ```java -jar Arctic.jar test finish <testName> <testCase> <result>```. We can use result to tell **Arctic** whether anything has gone wrong on the test side, for example, based on the return code of the test. If result is true and all screenshots captured during the test are considered good enough, **Arctic** will mark the test as OK. If any of the screenshots were different or the result is false, **Arctic** will mark the test as failed.
+Once the test is finished, we can pass this information to **Arctic** with ```java -jar arctic-<VERSION>.jar test finish <testName> <testCase> <result>```. We can use result to tell **Arctic** whether anything has gone wrong on the test side, for example, based on the return code of the test. If result is true and all screenshots captured during the test are considered good enough, **Arctic** will mark the test as OK. If any of the screenshots were different or the result is false, **Arctic** will mark the test as failed.
 
 ### Getting Arctic results
 
-Once all the tests have run, we can export the results into one of the supported formats  **junit**, **tap**, or **jtx**. Such report files that will contain a list of the tests that **passed/failed** can be generated with ```java -jar Arctic.jar <format> save <filename>```. For example, generated jtx files for failed tests can later be used as exclude files for jtHarness.
+Once all the tests have run, we can export the results into one of the supported formats  **junit**, **tap**, or **jtx**. Such report files that will contain a list of the tests that **passed/failed** can be generated with ```java -jar arctic-<VERSION>.jar <format> save <filename>```. For example, generated jtx files for failed tests can later be used as exclude files for jtHarness.
 Valid formats are:
 
 - **xml**: junit xml report
@@ -93,7 +93,7 @@ Valid formats are:
 
 ### Review screenshot comparisons
 
-For multiple reasons, tests may not pass for the first time after recording. The results can be reviewed by using the **Arctic** command sc. For example, ```java -jar Arctic.jar -c sc all``` will start a review of all the screenshots that failed in the current session. This can help you identify why the recording failed, and also add the current screenshot as an alternative to be compared in future runs.
+For multiple reasons, tests may not pass for the first time after recording. The results can be reviewed by using the **Arctic** command sc. For example, ```java -jar arctic-<VERSION>.jar -c sc all``` will start a review of all the screenshots that failed in the current session. This can help you identify why the recording failed, and also add the current screenshot as an alternative to be compared in future runs.
 
 ### Contribution Guidelines Instructions
 

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -18,9 +18,9 @@ sourceCompatibility = JavaVersion.VERSION_1_8
 project.buildDir = file("$rootDir/build/${project.name}/")
 
 jar {
-    archiveBaseName.set('ArcticShared')
+    archiveBaseName.set("arctic-api")
     manifest.attributes(
-            'Implementation-Title': 'ArcticShared',
+            'Implementation-Title': 'arctic-api',
             'Implementation-Vendor': 'Amazon Corretto Team',
             'Implementation-Version': getArchiveVersion()
     )

--- a/api/src/main/java/com/amazon/corretto/arctic/api/exception/ArcticException.java
+++ b/api/src/main/java/com/amazon/corretto/arctic/api/exception/ArcticException.java
@@ -13,9 +13,16 @@
  *   See the License for the specific language governing permissions and
  *   limitations under the License.
  */
+package com.amazon.corretto.arctic.api.exception;
 
-/**
- * This package contains interfaces and utility classes that are used for rmi communication between arctic and other
- * components.
- */
-package com.amazon.corretto.arctic.shared.rmi;
+public class ArcticException extends RuntimeException {
+    private static final long serialVersionUID = 1701825321560163787L;
+
+    public ArcticException(final String message) {
+        super(message);
+    }
+
+    public ArcticException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/api/src/main/java/com/amazon/corretto/arctic/api/rmi/ArcticRmiCommandClient.java
+++ b/api/src/main/java/com/amazon/corretto/arctic/api/rmi/ArcticRmiCommandClient.java
@@ -13,7 +13,7 @@
  *   See the License for the specific language governing permissions and
  *   limitations under the License.
  */
-package com.amazon.corretto.arctic.shared.rmi;
+package com.amazon.corretto.arctic.api.rmi;
 
 import java.rmi.NotBoundException;
 import java.rmi.RemoteException;

--- a/api/src/main/java/com/amazon/corretto/arctic/api/rmi/ArcticRmiCommandInterface.java
+++ b/api/src/main/java/com/amazon/corretto/arctic/api/rmi/ArcticRmiCommandInterface.java
@@ -13,16 +13,15 @@
  *   See the License for the specific language governing permissions and
  *   limitations under the License.
  */
-package com.amazon.corretto.arctic.shared.exception;
 
-public class ArcticException extends RuntimeException {
-    private static final long serialVersionUID = 1701825321560163787L;
+package com.amazon.corretto.arctic.api.rmi;
 
-    public ArcticException(final String message) {
-        super(message);
-    }
+import java.rmi.Remote;
+import java.rmi.RemoteException;
 
-    public ArcticException(final String message, final Throwable cause) {
-        super(message, cause);
+public interface ArcticRmiCommandInterface extends Remote {
+    String runCommand(String[] command) throws RemoteException;
+    default String runCommandLine(String command) throws RemoteException {
+        return runCommand(command.split(" "));
     }
 }

--- a/api/src/main/java/com/amazon/corretto/arctic/api/rmi/package-info.java
+++ b/api/src/main/java/com/amazon/corretto/arctic/api/rmi/package-info.java
@@ -14,14 +14,8 @@
  *   limitations under the License.
  */
 
-package com.amazon.corretto.arctic.shared.rmi;
-
-import java.rmi.Remote;
-import java.rmi.RemoteException;
-
-public interface ArcticRmiCommandInterface extends Remote {
-    String runCommand(String[] command) throws RemoteException;
-    default String runCommandLine(String command) throws RemoteException {
-        return runCommand(command.split(" "));
-    }
-}
+/**
+ * This package contains interfaces and utility classes that are used for rmi communication between arctic and other
+ * components.
+ */
+package com.amazon.corretto.arctic.api.rmi;

--- a/cmd_client/build.gradle
+++ b/cmd_client/build.gradle
@@ -18,9 +18,9 @@ sourceCompatibility = JavaVersion.VERSION_11
 project.buildDir = file("$rootDir/build/${project.name}/")
 
 jar {
-    archiveBaseName.set('ArcticCmd')
+    archiveBaseName.set('arctic-cmd')
     manifest.attributes(
-            'Implementation-Title': 'ArcticCmd',
+            'Implementation-Title': 'arctic-cmd',
             'Implementation-Vendor': 'Amazon Corretto Team',
             'Implementation-Version': getArchiveVersion()
     )

--- a/cmd_client/src/main/java/com/amazon/corretto/arctic/cmd/client/Main.java
+++ b/cmd_client/src/main/java/com/amazon/corretto/arctic/cmd/client/Main.java
@@ -20,7 +20,7 @@ import java.io.IOException;
 
 import com.amazon.corretto.arctic.cmd.client.inject.ArcticCmdModule;
 import com.amazon.corretto.arctic.common.BaseMain;
-import com.amazon.corretto.arctic.shared.exception.ArcticException;
+import com.amazon.corretto.arctic.api.exception.ArcticException;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import org.apache.commons.configuration2.Configuration;

--- a/cmd_client/src/main/java/com/amazon/corretto/arctic/cmd/client/command/impl/RemoteCommand.java
+++ b/cmd_client/src/main/java/com/amazon/corretto/arctic/cmd/client/command/impl/RemoteCommand.java
@@ -19,7 +19,7 @@ package com.amazon.corretto.arctic.cmd.client.command.impl;
 import javax.inject.Inject;
 
 import com.amazon.corretto.arctic.common.command.ArcticCommand;
-import com.amazon.corretto.arctic.shared.rmi.ArcticRmiCommandClient;
+import com.amazon.corretto.arctic.api.rmi.ArcticRmiCommandClient;
 
 /**
  * Forces a command to be executed remotely, even if it would be possible to execute that command locally.

--- a/cmd_client/src/main/java/com/amazon/corretto/arctic/cmd/client/inject/ArcticCmdModule.java
+++ b/cmd_client/src/main/java/com/amazon/corretto/arctic/cmd/client/inject/ArcticCmdModule.java
@@ -22,7 +22,7 @@ import javax.inject.Singleton;
 
 import com.amazon.corretto.arctic.common.inject.ArcticModule;
 import com.amazon.corretto.arctic.common.inject.CommonInjectionKeys;
-import com.amazon.corretto.arctic.shared.rmi.ArcticRmiCommandClient;
+import com.amazon.corretto.arctic.api.rmi.ArcticRmiCommandClient;
 import com.google.inject.Provides;
 import org.apache.commons.configuration2.Configuration;
 

--- a/cmd_client/src/main/java/com/amazon/corretto/arctic/cmd/client/rmi/impl/ClientRmiInterceptor.java
+++ b/cmd_client/src/main/java/com/amazon/corretto/arctic/cmd/client/rmi/impl/ClientRmiInterceptor.java
@@ -19,7 +19,7 @@ package com.amazon.corretto.arctic.cmd.client.rmi.impl;
 import javax.inject.Inject;
 
 import com.amazon.corretto.arctic.common.command.impl.BaseCommand;
-import com.amazon.corretto.arctic.shared.rmi.ArcticRmiCommandClient;
+import com.amazon.corretto.arctic.api.rmi.ArcticRmiCommandClient;
 
 /**
  * Most commands are executed via RMI, contacting the ArcticPlayer or ArcticRecorder running. But some commands can be

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -22,9 +22,9 @@ sourceCompatibility = JavaVersion.VERSION_11
 project.buildDir = file("$rootDir/build/${project.name}/")
 
 jar {
-    archiveBaseName.set('ArcticCommon')
+    archiveBaseName.set('arctic-common')
     manifest.attributes(
-            'Implementation-Title': 'ArcticCommon',
+            'Implementation-Title': 'arctic-common',
             'Implementation-Vendor': 'Amazon Corretto Team',
             'Implementation-Version': getArchiveVersion()
     )
@@ -32,7 +32,7 @@ jar {
 }
 
 dependencies {
-    api project(':shared')
+    api project(':api')
     api 'com.github.kwhat:jnativehook:2.2.2'
     api 'org.apache.commons:commons-configuration2:2.7'
     api 'org.slf4j:slf4j-api:1.7.36'

--- a/common/src/main/java/com/amazon/corretto/arctic/common/BaseMain.java
+++ b/common/src/main/java/com/amazon/corretto/arctic/common/BaseMain.java
@@ -27,7 +27,7 @@ import java.nio.file.StandardCopyOption;
 import java.util.Arrays;
 import java.util.List;
 
-import com.amazon.corretto.arctic.shared.exception.ArcticException;
+import com.amazon.corretto.arctic.api.exception.ArcticException;
 import org.apache.commons.configuration2.CombinedConfiguration;
 import org.apache.commons.configuration2.Configuration;
 import org.apache.commons.configuration2.PropertiesConfiguration;

--- a/common/src/main/java/com/amazon/corretto/arctic/common/backend/impl/JavaImageIoSaver.java
+++ b/common/src/main/java/com/amazon/corretto/arctic/common/backend/impl/JavaImageIoSaver.java
@@ -22,7 +22,7 @@ import javax.imageio.ImageIO;
 import javax.inject.Inject;
 
 import com.amazon.corretto.arctic.common.backend.ArcticImageSaver;
-import com.amazon.corretto.arctic.shared.exception.ArcticException;
+import com.amazon.corretto.arctic.api.exception.ArcticException;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/common/src/main/java/com/amazon/corretto/arctic/common/backend/impl/MessageDigestHashCalculator.java
+++ b/common/src/main/java/com/amazon/corretto/arctic/common/backend/impl/MessageDigestHashCalculator.java
@@ -25,7 +25,7 @@ import java.security.NoSuchAlgorithmException;
 import javax.imageio.ImageIO;
 
 import com.amazon.corretto.arctic.common.backend.ArcticHashCalculator;
-import com.amazon.corretto.arctic.shared.exception.ArcticException;
+import com.amazon.corretto.arctic.api.exception.ArcticException;
 import lombok.extern.slf4j.Slf4j;
 
 /**

--- a/common/src/main/java/com/amazon/corretto/arctic/common/command/interpreter/impl/ArcticRmiInterpreter.java
+++ b/common/src/main/java/com/amazon/corretto/arctic/common/command/interpreter/impl/ArcticRmiInterpreter.java
@@ -32,8 +32,8 @@ import javax.inject.Singleton;
 
 import com.amazon.corretto.arctic.common.command.impl.BaseCommand;
 import com.amazon.corretto.arctic.common.inject.CommonInjectionKeys;
-import com.amazon.corretto.arctic.shared.exception.ArcticException;
-import com.amazon.corretto.arctic.shared.rmi.ArcticRmiCommandInterface;
+import com.amazon.corretto.arctic.api.exception.ArcticException;
+import com.amazon.corretto.arctic.api.rmi.ArcticRmiCommandInterface;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/common/src/main/java/com/amazon/corretto/arctic/common/exception/ArcticConfigurationException.java
+++ b/common/src/main/java/com/amazon/corretto/arctic/common/exception/ArcticConfigurationException.java
@@ -17,7 +17,7 @@ package com.amazon.corretto.arctic.common.exception;
 
 import java.util.Collection;
 
-import com.amazon.corretto.arctic.shared.exception.ArcticException;
+import com.amazon.corretto.arctic.api.exception.ArcticException;
 
 /**
  * An exception to represent problems when reading configuration from the properties file.

--- a/common/src/main/java/com/amazon/corretto/arctic/common/repository/impl/JsonFileTestLoadRepositoryImpl.java
+++ b/common/src/main/java/com/amazon/corretto/arctic/common/repository/impl/JsonFileTestLoadRepositoryImpl.java
@@ -30,7 +30,7 @@ import com.amazon.corretto.arctic.common.model.ArcticTest;
 import com.amazon.corretto.arctic.common.model.TestId;
 import com.amazon.corretto.arctic.common.model.event.Events;
 import com.amazon.corretto.arctic.common.repository.TestLoadRepository;
-import com.amazon.corretto.arctic.shared.exception.ArcticException;
+import com.amazon.corretto.arctic.api.exception.ArcticException;
 import com.google.gson.Gson;
 import lombok.extern.slf4j.Slf4j;
 

--- a/common/src/main/java/com/amazon/corretto/arctic/common/repository/impl/JsonFileTestSaveRepositoryImpl.java
+++ b/common/src/main/java/com/amazon/corretto/arctic/common/repository/impl/JsonFileTestSaveRepositoryImpl.java
@@ -40,7 +40,7 @@ import com.amazon.corretto.arctic.common.model.TestId;
 import com.amazon.corretto.arctic.common.model.event.ScreenshotCheck;
 import com.amazon.corretto.arctic.common.repository.TestSaveRepository;
 import com.amazon.corretto.arctic.common.util.Pair;
-import com.amazon.corretto.arctic.shared.exception.ArcticException;
+import com.amazon.corretto.arctic.api.exception.ArcticException;
 import com.google.gson.Gson;
 import lombok.extern.slf4j.Slf4j;
 

--- a/launcher/build.gradle
+++ b/launcher/build.gradle
@@ -20,9 +20,9 @@ project.buildDir = file("$rootDir/build/${project.name}/")
 jar {
     dependsOn(":common:jar", ":player:jar", ":recorder:jar", ":cmd_client:jar")
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
-    archiveFileName.set('Arctic.jar')
+    archiveBaseName.set('arctic')
     manifest.attributes(
-            'Implementation-Title': 'Arctic',
+            'Implementation-Title': 'arctic',
             'Implementation-Vendor': 'Amazon Corretto Team',
             'Implementation-Version': getArchiveVersion(),
             'Main-Class': 'com.amazon.corretto.arctic.launcher.Main'

--- a/player/build.gradle
+++ b/player/build.gradle
@@ -19,9 +19,9 @@ project.buildDir = file("$rootDir/build/${project.name}/")
 
 jar {
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE // allow duplicates
-    archiveBaseName.set('ArcticPlayer')
+    archiveBaseName.set('arctic-player')
     manifest.attributes(
-            'Implementation-Title': 'ArcticPlayer',
+            'Implementation-Title': 'arctic-player',
             'Implementation-Vendor': 'Amazon Corretto Team',
             'Implementation-Version': getArchiveVersion()
     )

--- a/player/src/main/java/com/amazon/corretto/arctic/player/Main.java
+++ b/player/src/main/java/com/amazon/corretto/arctic/player/Main.java
@@ -25,7 +25,7 @@ import com.amazon.corretto.arctic.common.command.interpreter.impl.ConsoleCommand
 import com.amazon.corretto.arctic.common.control.TestController;
 import com.amazon.corretto.arctic.common.inject.CommonInjectionKeys;
 import com.amazon.corretto.arctic.player.inject.ArcticPlayerModule;
-import com.amazon.corretto.arctic.shared.exception.ArcticException;
+import com.amazon.corretto.arctic.api.exception.ArcticException;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.google.inject.Key;

--- a/player/src/main/java/com/amazon/corretto/arctic/player/backend/impl/ArcticImageCheckPlayer.java
+++ b/player/src/main/java/com/amazon/corretto/arctic/player/backend/impl/ArcticImageCheckPlayer.java
@@ -27,7 +27,7 @@ import com.amazon.corretto.arctic.player.backend.ArcticBackendPlayer;
 import com.amazon.corretto.arctic.player.backend.ImageComparator;
 import com.amazon.corretto.arctic.player.control.TimeController;
 import com.amazon.corretto.arctic.player.model.ArcticRunningTest;
-import com.amazon.corretto.arctic.shared.exception.ArcticException;
+import com.amazon.corretto.arctic.api.exception.ArcticException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/player/src/main/java/com/amazon/corretto/arctic/player/backend/impl/AwtRobotKeyboardBackendPlayer.java
+++ b/player/src/main/java/com/amazon/corretto/arctic/player/backend/impl/AwtRobotKeyboardBackendPlayer.java
@@ -28,7 +28,7 @@ import com.amazon.corretto.arctic.common.model.event.KeyboardEvent;
 import com.amazon.corretto.arctic.common.model.event.ScreenshotCheck;
 import com.amazon.corretto.arctic.player.backend.ArcticBackendPlayer;
 import com.amazon.corretto.arctic.player.inject.InjectionKeys;
-import com.amazon.corretto.arctic.shared.exception.ArcticException;
+import com.amazon.corretto.arctic.api.exception.ArcticException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/player/src/main/java/com/amazon/corretto/arctic/player/backend/impl/AwtRobotMouseBackendPlayer.java
+++ b/player/src/main/java/com/amazon/corretto/arctic/player/backend/impl/AwtRobotMouseBackendPlayer.java
@@ -26,7 +26,7 @@ import com.amazon.corretto.arctic.common.model.event.MouseEvent;
 import com.amazon.corretto.arctic.player.backend.ArcticBackendPlayer;
 import com.amazon.corretto.arctic.player.inject.InjectionKeys;
 import com.amazon.corretto.arctic.player.model.ArcticRunningTest;
-import com.amazon.corretto.arctic.shared.exception.ArcticException;
+import com.amazon.corretto.arctic.api.exception.ArcticException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/player/src/main/java/com/amazon/corretto/arctic/player/backend/impl/JnhKeyboardBackendPlayer.java
+++ b/player/src/main/java/com/amazon/corretto/arctic/player/backend/impl/JnhKeyboardBackendPlayer.java
@@ -24,7 +24,7 @@ import com.amazon.corretto.arctic.common.model.event.ArcticEvent;
 import com.amazon.corretto.arctic.common.model.event.KeyboardEvent;
 import com.amazon.corretto.arctic.common.model.event.ScreenshotCheck;
 import com.amazon.corretto.arctic.player.backend.ArcticBackendPlayer;
-import com.amazon.corretto.arctic.shared.exception.ArcticException;
+import com.amazon.corretto.arctic.api.exception.ArcticException;
 import com.github.kwhat.jnativehook.GlobalScreen;
 import com.github.kwhat.jnativehook.keyboard.NativeKeyEvent;
 import org.slf4j.Logger;

--- a/player/src/main/java/com/amazon/corretto/arctic/player/backend/impl/JnhMouseBackendPlayer.java
+++ b/player/src/main/java/com/amazon/corretto/arctic/player/backend/impl/JnhMouseBackendPlayer.java
@@ -27,7 +27,7 @@ import com.amazon.corretto.arctic.player.backend.ArcticBackendPlayer;
 import com.amazon.corretto.arctic.player.backend.converters.ArcticMouseEvent2JnhMouseEvent;
 import com.amazon.corretto.arctic.player.inject.InjectionKeys;
 import com.amazon.corretto.arctic.player.model.ArcticRunningTest;
-import com.amazon.corretto.arctic.shared.exception.ArcticException;
+import com.amazon.corretto.arctic.api.exception.ArcticException;
 import com.github.kwhat.jnativehook.GlobalScreen;
 import com.github.kwhat.jnativehook.mouse.NativeMouseEvent;
 import org.slf4j.Logger;

--- a/player/src/main/java/com/amazon/corretto/arctic/player/backend/impl/JnhMouseWheelBackendPlayer.java
+++ b/player/src/main/java/com/amazon/corretto/arctic/player/backend/impl/JnhMouseWheelBackendPlayer.java
@@ -23,7 +23,7 @@ import com.amazon.corretto.arctic.common.model.event.ScreenshotCheck;
 import com.amazon.corretto.arctic.player.backend.ArcticBackendPlayer;
 import com.amazon.corretto.arctic.player.backend.converters.ArcticMouseEvent2JnhMouseWheelEvent;
 import com.amazon.corretto.arctic.player.model.ArcticRunningTest;
-import com.amazon.corretto.arctic.shared.exception.ArcticException;
+import com.amazon.corretto.arctic.api.exception.ArcticException;
 import com.github.kwhat.jnativehook.GlobalScreen;
 import com.github.kwhat.jnativehook.mouse.NativeMouseWheelEvent;
 import org.slf4j.Logger;

--- a/player/src/main/java/com/amazon/corretto/arctic/player/backend/pixel/check/LoadRecordedPixelCheck.java
+++ b/player/src/main/java/com/amazon/corretto/arctic/player/backend/pixel/check/LoadRecordedPixelCheck.java
@@ -26,7 +26,7 @@ import com.amazon.corretto.arctic.common.repository.TestLoadRepository;
 import com.amazon.corretto.arctic.player.backend.pixel.PixelCheck;
 import com.amazon.corretto.arctic.player.backend.pixel.PixelCheckResult;
 import com.amazon.corretto.arctic.player.model.ArcticDiffImages;
-import com.amazon.corretto.arctic.shared.exception.ArcticException;
+import com.amazon.corretto.arctic.api.exception.ArcticException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/player/src/main/java/com/amazon/corretto/arctic/player/control/impl/AdvancedTimeController.java
+++ b/player/src/main/java/com/amazon/corretto/arctic/player/control/impl/AdvancedTimeController.java
@@ -26,7 +26,7 @@ import com.amazon.corretto.arctic.common.model.event.ArcticEvent;
 import com.amazon.corretto.arctic.common.tweak.ArcticTweakableComponent;
 import com.amazon.corretto.arctic.common.tweak.TweakKeys;
 import com.amazon.corretto.arctic.player.control.TimeController;
-import com.amazon.corretto.arctic.shared.exception.ArcticException;
+import com.amazon.corretto.arctic.api.exception.ArcticException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/player/src/main/java/com/amazon/corretto/arctic/player/preprocessing/impl/EventsLoaderPreProcessor.java
+++ b/player/src/main/java/com/amazon/corretto/arctic/player/preprocessing/impl/EventsLoaderPreProcessor.java
@@ -23,7 +23,7 @@ import com.amazon.corretto.arctic.common.repository.TestLoadRepository;
 import com.amazon.corretto.arctic.player.model.ArcticRunningTest;
 import com.amazon.corretto.arctic.player.model.TestStatusCode;
 import com.amazon.corretto.arctic.player.preprocessing.ArcticPlayerPreProcessor;
-import com.amazon.corretto.arctic.shared.exception.ArcticException;
+import com.amazon.corretto.arctic.api.exception.ArcticException;
 
 /**
  * Most of the information of the test, like the actual events recording, is only loaded on demand, as it is

--- a/player/src/main/resources/player.properties
+++ b/player/src/main/resources/player.properties
@@ -118,7 +118,7 @@ arctic.player.backend.jnhMouse.events = 0x03700
 arctic.player.backend.awtKeyboard.keymap.bundled = true
 
 # Bundled resource name or path to the file with the keymap.
-# These files can be generated running `java -jar Arctic.jar -d`.
+# These files can be generated running `java -jar arctic-<VERSION>.jar -d`.
 arctic.player.backend.awtKeyboard.keymap = keymap_linux.txt
 
 # Define which image comparator to use when reproducing the tests

--- a/recorder/build.gradle
+++ b/recorder/build.gradle
@@ -19,9 +19,9 @@ project.buildDir = file("$rootDir/build/${project.name}/")
 
 jar {
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE // allow duplicates
-    archiveBaseName.set('ArcticRecorder')
+    archiveBaseName.set('arctic-recorder')
     manifest.attributes(
-            'Implementation-Title': 'ArcticRecorder',
+            'Implementation-Title': 'arctic-recorder',
             'Implementation-Vendor': 'Amazon Corretto Team',
             'Implementation-Version': getArchiveVersion()
     )

--- a/recorder/src/main/java/com/amazon/corretto/arctic/recorder/Main.java
+++ b/recorder/src/main/java/com/amazon/corretto/arctic/recorder/Main.java
@@ -29,7 +29,7 @@ import com.amazon.corretto.arctic.common.control.TestController;
 import com.amazon.corretto.arctic.common.inject.CommonInjectionKeys;
 import com.amazon.corretto.arctic.recorder.control.ArcticController;
 import com.amazon.corretto.arctic.recorder.inject.ArcticRecorderModule;
-import com.amazon.corretto.arctic.shared.exception.ArcticException;
+import com.amazon.corretto.arctic.api.exception.ArcticException;
 import com.github.kwhat.jnativehook.GlobalScreen;
 import com.google.inject.Guice;
 import com.google.inject.Injector;

--- a/recorder/src/main/java/com/amazon/corretto/arctic/recorder/control/impl/JnhKeyCaptureController.java
+++ b/recorder/src/main/java/com/amazon/corretto/arctic/recorder/control/impl/JnhKeyCaptureController.java
@@ -25,7 +25,6 @@ import javax.inject.Singleton;
 
 import com.amazon.corretto.arctic.recorder.control.ArcticController;
 import com.amazon.corretto.arctic.recorder.inject.InjectionKeys;
-import com.amazon.corretto.arctic.shared.exception.ArcticException;
 import com.github.kwhat.jnativehook.GlobalScreen;
 import com.github.kwhat.jnativehook.NativeHookException;
 import com.github.kwhat.jnativehook.keyboard.NativeKeyEvent;

--- a/recorder/src/main/java/com/amazon/corretto/arctic/recorder/identification/impl/AwtRobotOffsetCalculator.java
+++ b/recorder/src/main/java/com/amazon/corretto/arctic/recorder/identification/impl/AwtRobotOffsetCalculator.java
@@ -28,7 +28,7 @@ import com.amazon.corretto.arctic.common.model.gui.Point;
 import com.amazon.corretto.arctic.common.model.gui.ScreenArea;
 import com.amazon.corretto.arctic.recorder.identification.ArcticTestWindowOffsetCalculator;
 import com.amazon.corretto.arctic.recorder.inject.InjectionKeys;
-import com.amazon.corretto.arctic.shared.exception.ArcticException;
+import com.amazon.corretto.arctic.api.exception.ArcticException;
 import lombok.extern.slf4j.Slf4j;
 
 /**

--- a/recorder/src/main/java/com/amazon/corretto/arctic/recorder/inject/ArcticRecorderOffsetModule.java
+++ b/recorder/src/main/java/com/amazon/corretto/arctic/recorder/inject/ArcticRecorderOffsetModule.java
@@ -29,7 +29,7 @@ import com.amazon.corretto.arctic.common.inject.CommonInjectionKeys;
 import com.amazon.corretto.arctic.recorder.identification.ArcticTestWindowOffsetCalculator;
 import com.amazon.corretto.arctic.recorder.identification.impl.AwtRobotOffsetCalculator;
 import com.amazon.corretto.arctic.recorder.identification.impl.FixedPointOffsetCalculator;
-import com.amazon.corretto.arctic.shared.exception.ArcticException;
+import com.amazon.corretto.arctic.api.exception.ArcticException;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.configuration2.Configuration;
 

--- a/recorder/src/main/java/com/amazon/corretto/arctic/recorder/postprocessing/impl/ScreenCheckHashPostProcessor.java
+++ b/recorder/src/main/java/com/amazon/corretto/arctic/recorder/postprocessing/impl/ScreenCheckHashPostProcessor.java
@@ -24,7 +24,7 @@ import com.amazon.corretto.arctic.common.model.ArcticTest;
 import com.amazon.corretto.arctic.common.model.event.ScreenshotCheck;
 import com.amazon.corretto.arctic.recorder.inject.InjectionKeys;
 import com.amazon.corretto.arctic.recorder.postprocessing.ArcticRecorderPostProcessor;
-import com.amazon.corretto.arctic.shared.exception.ArcticException;
+import com.amazon.corretto.arctic.api.exception.ArcticException;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j

--- a/recorder/src/main/java/com/amazon/corretto/arctic/recorder/preprocessing/impl/FirstScCheckPreProcessor.java
+++ b/recorder/src/main/java/com/amazon/corretto/arctic/recorder/preprocessing/impl/FirstScCheckPreProcessor.java
@@ -26,7 +26,7 @@ import com.amazon.corretto.arctic.common.model.event.ScreenshotCheck;
 import com.amazon.corretto.arctic.common.model.gui.ScreenArea;
 import com.amazon.corretto.arctic.recorder.inject.InjectionKeys;
 import com.amazon.corretto.arctic.recorder.preprocessing.ArcticRecorderPreProcessor;
-import com.amazon.corretto.arctic.shared.exception.ArcticException;
+import com.amazon.corretto.arctic.api.exception.ArcticException;
 
 public final class FirstScCheckPreProcessor implements ArcticRecorderPreProcessor {
     private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(FirstScCheckPreProcessor.class);

--- a/settings.gradle
+++ b/settings.gradle
@@ -16,7 +16,7 @@
 
 rootProject.name = 'arctic'
 
-include ':shared',
+include ':api',
         ':common',
         ':recorder',
         ':player',


### PR DESCRIPTION
### Description
This renames the output jars:
Arctic.jar -> arctic-<VERSION>.jar
ArcticShared.jar -> arctic-api-<VERSION>.jar

### Motivation and context
We should follow the naming convention for jars

### How has this been tested?
Recorded and replayed jtreg tests on mac

### Platform information
    Works on OS: [e.g. Amazon Linux 2 only]
    Applies to version [e.g. "0.4.12" (output from "java -jar Arctic.jar -v")]


### Additional context



### Contribution confirmation

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

