### PR TITLE
Ignore failures in checkstyle until 100% compliant

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,7 @@ allprojects {
 
     checkstyle {
       toolVersion '8.41'
+      ignoreFailures true
     }
 
     version = { file('version.txt').text.trim() }.call()


### PR DESCRIPTION
### Motivation and context
Arctic still has some checkstyle failures. Prevent the build from failing until they are fixed

### How has this been tested?
./gradlew build now builds the project

### Platform information
    Works on OS: [e.g. Amazon Linux 2 only]
    Applies to version [e.g. "0.4.12" (output from "java -jar Arctic.jar -v")]


### Additional context



### Contribution confirmation

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

