### PR TITLE
Update dependencies and gradle syntax

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -14,11 +14,12 @@
  *   limitations under the License.
  */
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-project.buildDir = file("$rootDir/build/${project.name}/")
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+}
 
 jar {
-    archiveBaseName.set("arctic-api")
+    archiveBaseName.set('arctic-api')
     manifest.attributes(
             'Implementation-Title': 'arctic-api',
             'Implementation-Vendor': 'Amazon Corretto Team',

--- a/build.gradle
+++ b/build.gradle
@@ -15,12 +15,14 @@
  */
 
 allprojects {
+    layout.buildDirectory = file("$rootDir/build/${project.name}/")
+
     apply plugin: 'java'
     apply plugin: 'checkstyle'
 
     checkstyle {
-      toolVersion '8.41'
-      ignoreFailures true
+      toolVersion = '8.41'
+      ignoreFailures = true
     }
 
     version = { file('version.txt').text.trim() }.call()

--- a/cmd_client/build.gradle
+++ b/cmd_client/build.gradle
@@ -14,8 +14,9 @@
  *   limitations under the License.
  */
 
-sourceCompatibility = JavaVersion.VERSION_11
-project.buildDir = file("$rootDir/build/${project.name}/")
+java {
+    sourceCompatibility = JavaVersion.VERSION_11
+}
 
 jar {
     archiveBaseName.set('arctic-cmd')

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -18,8 +18,9 @@ plugins {
     id 'java-library'
 }
 
-sourceCompatibility = JavaVersion.VERSION_11
-project.buildDir = file("$rootDir/build/${project.name}/")
+java {
+    sourceCompatibility = JavaVersion.VERSION_11
+}
 
 jar {
     archiveBaseName.set('arctic-common')
@@ -34,10 +35,10 @@ jar {
 dependencies {
     api project(':api')
     api 'com.github.kwhat:jnativehook:2.2.2'
-    api 'org.apache.commons:commons-configuration2:2.7'
-    api 'org.slf4j:slf4j-api:1.7.36'
-    api 'com.google.inject:guice:5.1.0'
-    api 'com.google.code.gson:gson:2.9.0'
-    compileOnly 'org.projectlombok:lombok:1.18.24'
-    annotationProcessor 'org.projectlombok:lombok:1.18.24'
+    api 'org.apache.commons:commons-configuration2:2.11.0'
+    api 'org.slf4j:slf4j-api:2.0.17'
+    api 'com.google.inject:guice:6.0.0'
+    api 'com.google.code.gson:gson:2.12.1'
+    compileOnly 'org.projectlombok:lombok:1.18.30'
+    annotationProcessor 'org.projectlombok:lombok:1.18.30'
 }

--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -14,8 +14,9 @@
  *   limitations under the License.
  */
 
-sourceCompatibility = JavaVersion.VERSION_11
-project.buildDir = file("$rootDir/build/${project.name}/")
+java {
+    sourceCompatibility = JavaVersion.VERSION_11
+}
 
 jar {
     archiveBaseName.set('demo')

--- a/launcher/build.gradle
+++ b/launcher/build.gradle
@@ -14,8 +14,9 @@
  *   limitations under the License.
  */
 
-sourceCompatibility = JavaVersion.VERSION_11
-project.buildDir = file("$rootDir/build/${project.name}/")
+java {
+    sourceCompatibility = JavaVersion.VERSION_11
+}
 
 jar {
     dependsOn(":common:jar", ":player:jar", ":recorder:jar", ":cmd_client:jar")
@@ -37,5 +38,5 @@ dependencies {
     implementation project(':recorder')
     implementation project(':cmd_client')
 
-    runtimeOnly 'org.slf4j:slf4j-jdk14:1.7.36'
+    runtimeOnly 'org.slf4j:slf4j-jdk14:2.0.17'
 }

--- a/player/build.gradle
+++ b/player/build.gradle
@@ -14,8 +14,9 @@
  *   limitations under the License.
  */
 
-sourceCompatibility = JavaVersion.VERSION_11
-project.buildDir = file("$rootDir/build/${project.name}/")
+java {
+    sourceCompatibility = JavaVersion.VERSION_11
+}
 
 jar {
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE // allow duplicates
@@ -37,9 +38,9 @@ test {
 dependencies {
     implementation project(':common')
 
-    testImplementation group: 'org.mockito', name: 'mockito-core', version: '3.7.7'
-    testImplementation group: 'org.mockito', name: 'mockito-junit-jupiter', version: '3.7.7'
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.7.1'
-    testImplementation 'org.junit.jupiter:junit-jupiter-params:5.7.1'
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.7.1'
+    testImplementation 'org.mockito:mockito-core:5.17.0'
+    testImplementation 'org.mockito:mockito-junit-jupiter:5.17.0'
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.12.1'
+    testImplementation 'org.junit.jupiter:junit-jupiter-params:5.12.1'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.12.1'
 }

--- a/recorder/build.gradle
+++ b/recorder/build.gradle
@@ -14,8 +14,9 @@
  *   limitations under the License.
  */
 
-sourceCompatibility = JavaVersion.VERSION_11
-project.buildDir = file("$rootDir/build/${project.name}/")
+java {
+    sourceCompatibility = JavaVersion.VERSION_11
+}
 
 jar {
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE // allow duplicates
@@ -30,6 +31,6 @@ jar {
 
 dependencies {
     implementation project(":common")
-    compileOnly 'org.projectlombok:lombok:1.18.24'
-    annotationProcessor 'org.projectlombok:lombok:1.18.24'
+    compileOnly 'org.projectlombok:lombok:1.18.30'
+    annotationProcessor 'org.projectlombok:lombok:1.18.30'
 }


### PR DESCRIPTION
### Description
Updates most dependencies to the latest stable version. It also fixes deprecation warnings for a future gradle 9 migrations.

By updating the dependencies it is now possible to build with JDK21