### PR TITLE
Adds a simple key test

### DIFF
--- a/common/src/main/java/com/amazon/corretto/arctic/common/BaseMain.java
+++ b/common/src/main/java/com/amazon/corretto/arctic/common/BaseMain.java
@@ -85,7 +85,8 @@ public abstract class BaseMain {
         PLAYER("p", "player", "Run Arctic Player"),
         COMMAND("c", "command", "Issue an Arctic command via RMI"),
         INTERACTIVE("i", "interactive", "Start an interactive Arctic CLI"),
-        DUMPER("d", "dumpkeys", "Dumps the awt/jnh table for this system");
+        DUMPER("d", "dumpkeys", "Dumps the awt/jnh table for this system"),
+        KEYTEST("k", "keytest", "Shows the keycode for individual keys");
 
         private static final int WIDTH = 25;
         private final String shortOption;
@@ -99,7 +100,8 @@ public abstract class BaseMain {
                 PLAYER,
                 COMMAND,
                 INTERACTIVE,
-                DUMPER);
+                DUMPER,
+                KEYTEST);
 
         CommandLineOption(final String shortOption, final String longOption, final String help) {
             this.shortOption = shortOption;

--- a/launcher/src/main/java/com/amazon/corretto/arctic/keycode/KeyTest.java
+++ b/launcher/src/main/java/com/amazon/corretto/arctic/keycode/KeyTest.java
@@ -1,0 +1,66 @@
+package com.amazon.corretto.arctic.keycode;
+
+import com.amazon.corretto.arctic.recorder.backend.converters.JnhNativeKeyEvent2ArcticEvent;
+import com.amazon.corretto.arctic.recorder.backend.impl.JnhKeyboardRecorder;
+import com.github.kwhat.jnativehook.GlobalScreen;
+import com.github.kwhat.jnativehook.NativeHookException;
+import com.github.kwhat.jnativehook.keyboard.NativeKeyEvent;
+import com.github.kwhat.jnativehook.keyboard.NativeKeyListener;
+
+public class KeyTest {
+    private final JnhKeyboardRecorder recorder;
+    private boolean registeredHook = false;
+
+    public static void main(final String... args) {
+        try {
+            new KeyTest();
+        } catch (Exception e) {
+            System.out.println("Error when running the keyboard test");
+            e.printStackTrace();
+        }
+    }
+
+    private KeyTest() {
+        recorder = new JnhKeyboardRecorder(new JnhNativeKeyEvent2ArcticEvent());
+        addShutdownHook();
+        GlobalScreen.addNativeKeyListener(new KeyListener());
+        registerHook();
+    }
+
+    private void addShutdownHook() {
+        Runtime.getRuntime().addShutdownHook(new Thread("shutdown-hook") {
+            @Override
+            public void run() {
+                unregisterHook();
+            }
+        });
+    }
+
+    private void registerHook() {
+        if (!GlobalScreen.isNativeHookRegistered()) {
+            try {
+                GlobalScreen.registerNativeHook();
+                registeredHook = true;
+            } catch (final NativeHookException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    private void unregisterHook() {
+        if (registeredHook) {
+            try {
+                GlobalScreen.unregisterNativeHook();
+                registeredHook = false;
+            } catch (final NativeHookException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    public static class KeyListener implements NativeKeyListener {
+        public void nativeKeyPressed(NativeKeyEvent e) {
+            System.out.printf("Key code: %5d %s%n", e.getKeyCode(), NativeKeyEvent.getKeyText(e.getKeyCode()));
+        }
+    }
+}

--- a/launcher/src/main/java/com/amazon/corretto/arctic/launcher/Main.java
+++ b/launcher/src/main/java/com/amazon/corretto/arctic/launcher/Main.java
@@ -51,6 +51,8 @@ public class Main extends BaseMain {
             case DUMPER:
                 com.amazon.corretto.arctic.keycode.Dumper.main(args);
                 break;
+            case KEYTEST:
+                com.amazon.corretto.arctic.keycode.KeyTest.main(args);
             case VERSION:
                 printVersion();
                 break;


### PR DESCRIPTION
### Description
Adds a simple keytest mode that can be launched with:
```
java -jar arctic-<VERSION>.jar -k
```
This will print the keycode for the different keys pressed. This can be useful when deciding which keycodes configure in the recorder.properties to control arctic.

Output looks like:
```
Key code:    56 Alt
Key code:    29 Ctrl
Key code:    46 C
```

