### PR TITLE
Add option to use native screen capture utitlity to validate mouse cursor

### DIFF
--- a/common/src/main/java/com/amazon/corretto/arctic/common/backend/ArcticScreenRecorder.java
+++ b/common/src/main/java/com/amazon/corretto/arctic/common/backend/ArcticScreenRecorder.java
@@ -34,9 +34,17 @@ public interface ArcticScreenRecorder {
     ScreenshotCheck capture();
 
     /**
-     * Generates a ScreenshotCheck based on a specific area, ignoring the workbench position.
-     * @param area Area we will capture relative to the base area.
+     * Generates a ScreenshotCheck based on the workbench position.
+     * @param captureMouseCursor If true, the mouse cursor will be captured as well.
      * @return ScreenshotCheck with basic fields initialized (image, timestamp)
      */
-    ScreenshotCheck capture(ScreenArea area);
+    ScreenshotCheck capture(boolean captureMouseCursor);
+
+    /**
+     * Generates a ScreenshotCheck based on a specific area, ignoring the workbench position.
+     * @param area Area we will capture relative to the base area.
+     * @param captureMouseCursor If true, the mouse cursor will be captured as well.
+     * @return ScreenshotCheck with basic fields initialized (image, timestamp)
+     */
+    ScreenshotCheck capture(ScreenArea area, boolean captureMouseCursor);
 }

--- a/common/src/main/java/com/amazon/corretto/arctic/common/backend/impl/AwtRobotScreenRecorder.java
+++ b/common/src/main/java/com/amazon/corretto/arctic/common/backend/impl/AwtRobotScreenRecorder.java
@@ -72,6 +72,7 @@ public class AwtRobotScreenRecorder implements ArcticScreenRecorder {
         this.yMargin = yMargin;
         this.nativeCaptureToolLinux = nativeCaptureToolLinux;
     }
+    
 
     /**
      * {@inheritDoc}
@@ -128,7 +129,7 @@ public class AwtRobotScreenRecorder implements ArcticScreenRecorder {
                 captureCmdResult = saveScreenToFile("gnome-screenshot", "-p", "-f", filename);
             }
             else{
-                throw new RuntimeException("Unknown tool \'"+ this.nativeCaptureToolLinux + "\'");
+                throw new RuntimeException("Unknown tool \'"+ this.nativeCaptureToolLinux + "\'. Please check ");
             }
         } else if (os.contains("mac")) {
             throw new RuntimeException("Mac native capture is not supported yet");
@@ -138,14 +139,18 @@ public class AwtRobotScreenRecorder implements ArcticScreenRecorder {
             throw new RuntimeException(os + "native capture is not supported");
         }
         File imgFile = new File(filename);
-        if (captureCmdResult != 0 || !imgFile.exists()) {
-            if(imgFile.exists()){
-                imgFile.delete();
+        BufferedImage img;
+        try {
+            if (captureCmdResult != 0 || !imgFile.exists()) {
+                throw new RuntimeException("Failed to capture screen using native tool " + this.nativeCaptureToolLinux +
+                    ". Please make sure it is installed and available in PATH."
+                );
             }
-            throw new RuntimeException("Failed to capture screen using native tool");
+            img = getCroppedImageFromFile(area.asRectangle(), imgFile);
         }
-        BufferedImage img = getCroppedImageFromFile(area.asRectangle(), imgFile);
-        imgFile.delete();
+        finally {
+            imgFile.delete();
+        }
         return img;
     }
 

--- a/common/src/main/java/com/amazon/corretto/arctic/common/backend/impl/AwtRobotScreenRecorder.java
+++ b/common/src/main/java/com/amazon/corretto/arctic/common/backend/impl/AwtRobotScreenRecorder.java
@@ -122,11 +122,11 @@ public class AwtRobotScreenRecorder implements ArcticScreenRecorder {
         if (os.contains("linux")) {
             captureCmdResult = saveScreenToFile("gnome-screenshot", "-p", "-f", filename);
         } else if (os.contains("mac")) {
-            captureCmdResult = saveScreenToFile("screencapture", "-C", filename);
+            throw new RuntimeException("Mac native capture is not supported yet");
         } else if (os.contains("win")) {
-            throw new RuntimeException("Windows is not supported yet");
+            throw new RuntimeException("Windows native capture is not supported yet");
         } else {
-            throw new RuntimeException(os + " is not supported");
+            throw new RuntimeException(os + "native capture is not supported");
         }
         if (captureCmdResult != 0) {
             throw new RuntimeException("Failed to capture screen using native tool");

--- a/common/src/main/java/com/amazon/corretto/arctic/common/backend/impl/AwtRobotScreenRecorder.java
+++ b/common/src/main/java/com/amazon/corretto/arctic/common/backend/impl/AwtRobotScreenRecorder.java
@@ -15,7 +15,8 @@
  */
 package com.amazon.corretto.arctic.common.backend.impl;
 
-import java.awt.*;
+import java.awt.Robot;
+import java.awt.Rectangle;
 import java.awt.image.BufferedImage;
 import java.io.BufferedReader;
 import java.io.File;
@@ -47,6 +48,7 @@ public class AwtRobotScreenRecorder implements ArcticScreenRecorder {
     private final int xMargin;
     private final int yMargin;
     private static final Logger log = LoggerFactory.getLogger(AwtRobotScreenRecorder.class);
+    private final String nativeCaptureToolLinux;
 
     /**
      * Creates a new instance of an AwtRobotScreenRecorder.
@@ -61,12 +63,14 @@ public class AwtRobotScreenRecorder implements ArcticScreenRecorder {
     @Inject
     public AwtRobotScreenRecorder(final Robot robot, final WorkbenchManager wbManager, final ShadeManager shadeManager,
                                   final @Named(CommonInjectionKeys.SCREEN_CAPTURE_MARGIN_X) int xMargin,
-                                  final @Named(CommonInjectionKeys.SCREEN_CAPTURE_MARGIN_Y) int yMargin) {
+                                  final @Named(CommonInjectionKeys.SCREEN_CAPTURE_MARGIN_Y) int yMargin,
+                                  final @Named(CommonInjectionKeys.NATIVE_CAPTURE_TOOL_LINUX) String nativeCaptureToolLinux) {
         this.robot = robot;
         this.wbManager = wbManager;
         this.shadeManager = shadeManager;
         this.xMargin = xMargin;
         this.yMargin = yMargin;
+        this.nativeCaptureToolLinux = nativeCaptureToolLinux;
     }
 
     /**
@@ -115,12 +119,17 @@ public class AwtRobotScreenRecorder implements ArcticScreenRecorder {
      * This method is used to capture the screen with the mouse cursor using OS native tool.
      * It saves image to file, then crops it and returns BufferedImage object.
      */
-    private static BufferedImage nativeCapture(final ScreenArea area) {
+    private BufferedImage nativeCapture(final ScreenArea area) {
         String os = System.getProperty("os.name").toLowerCase();
         String filename = "screen_" + System.currentTimeMillis() + ".png";
         int captureCmdResult = 0;
         if (os.contains("linux")) {
-            captureCmdResult = saveScreenToFile("gnome-screenshot", "-p", "-f", filename);
+            if(this.nativeCaptureToolLinux == "gnome-screenshot"){
+                captureCmdResult = saveScreenToFile("gnome-screenshot", "-p", "-f", filename);
+            }
+            else{
+                throw new RuntimeException("Unknown tool \'"+ this.nativeCaptureToolLinux + "\'");
+            }
         } else if (os.contains("mac")) {
             throw new RuntimeException("Mac native capture is not supported yet");
         } else if (os.contains("win")) {
@@ -140,7 +149,7 @@ public class AwtRobotScreenRecorder implements ArcticScreenRecorder {
     /*
      * Invoke native OS tool to save the screenshot to a file.
      */
-    public static int saveScreenToFile (String... nativeToolCmd) {
+    public int saveScreenToFile (String... nativeToolCmd) {
         ProcessBuilder processBuilder = new ProcessBuilder(nativeToolCmd);
         processBuilder.redirectErrorStream(true);
         int screenShotRun = 0;

--- a/common/src/main/java/com/amazon/corretto/arctic/common/backend/impl/AwtRobotScreenRecorder.java
+++ b/common/src/main/java/com/amazon/corretto/arctic/common/backend/impl/AwtRobotScreenRecorder.java
@@ -124,7 +124,7 @@ public class AwtRobotScreenRecorder implements ArcticScreenRecorder {
         String filename = "screen_" + System.currentTimeMillis() + ".png";
         int captureCmdResult = 0;
         if (os.contains("linux")) {
-            if(this.nativeCaptureToolLinux == "gnome-screenshot"){
+            if(this.nativeCaptureToolLinux.equals("gnome-screenshot")){
                 captureCmdResult = saveScreenToFile("gnome-screenshot", "-p", "-f", filename);
             }
             else{

--- a/common/src/main/java/com/amazon/corretto/arctic/common/backend/impl/AwtRobotScreenRecorder.java
+++ b/common/src/main/java/com/amazon/corretto/arctic/common/backend/impl/AwtRobotScreenRecorder.java
@@ -15,8 +15,14 @@
  */
 package com.amazon.corretto.arctic.common.backend.impl;
 
-import java.awt.Robot;
+import java.awt.*;
 import java.awt.image.BufferedImage;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.stream.Collectors;
+import javax.imageio.ImageIO;
 
 import com.amazon.corretto.arctic.common.backend.ArcticScreenRecorder;
 import com.amazon.corretto.arctic.common.gui.ShadeManager;
@@ -26,6 +32,8 @@ import com.amazon.corretto.arctic.common.model.event.ScreenshotCheck;
 import com.amazon.corretto.arctic.common.model.gui.ScreenArea;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Captures a {@link ScreenshotCheck} using {@link Robot}. The ScreenshotCheck contains not only the image with the
@@ -38,6 +46,7 @@ public class AwtRobotScreenRecorder implements ArcticScreenRecorder {
     private final ShadeManager shadeManager;
     private final int xMargin;
     private final int yMargin;
+    private static final Logger log = LoggerFactory.getLogger(AwtRobotScreenRecorder.class);
 
     /**
      * Creates a new instance of an AwtRobotScreenRecorder.
@@ -65,27 +74,114 @@ public class AwtRobotScreenRecorder implements ArcticScreenRecorder {
      */
     @Override
     public ScreenshotCheck capture() {
+        return capture(false);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public ScreenshotCheck capture(boolean captureMouseCursor) {
         ScreenArea wbsa = wbManager.getScreenArea();
         ScreenArea targetsa = new ScreenArea(
                 wbsa.getX() < xMargin ? 0 : wbsa.getX(),
                 wbsa.getY() < yMargin ? 0 : wbsa.getY(),
                 wbsa.getX() < xMargin ? wbsa.getW() + wbsa.getX() : wbsa.getW(),
                 wbsa.getY() < yMargin ? wbsa.getH() + wbsa.getY() : wbsa.getH());
-        return capture(targetsa);
+        return capture(targetsa, captureMouseCursor);
     }
 
     /**
      * {@inheritDoc}
      */
     @Override
-    public ScreenshotCheck capture(final ScreenArea area) {
-        final BufferedImage image = robot.createScreenCapture(area.asRectangle());
+    public ScreenshotCheck capture(final ScreenArea area, boolean captureMouseCursor) {
+        final BufferedImage image;
+        if (captureMouseCursor) {
+            image = nativeCapture(area);
+        } else {
+            image = robot.createScreenCapture(area.asRectangle());
+        }
         final ScreenshotCheck sc = new ScreenshotCheck();
         sc.setImage(image);
         sc.setWorkbench(wbManager.getWorkbench());
         sc.setShades(shadeManager.getShades());
         sc.setSa(area);
         sc.setTimestamp(System.nanoTime());
+        sc.setMouseCursor(captureMouseCursor);
         return sc;
+    }
+    
+    /*
+     * This method is used to capture the screen with the mouse cursor using OS native tool.
+     * It saves image to file, then crops it and returns BufferedImage object.
+     */
+    private static BufferedImage nativeCapture(final ScreenArea area) {
+        String os = System.getProperty("os.name").toLowerCase();
+        String filename = "screen_" + System.currentTimeMillis() + ".png";
+        int captureCmdResult = 0;
+        if (os.contains("linux")) {
+            captureCmdResult = saveScreenToFile("gnome-screenshot", "-p", "-f", filename);
+        } else if (os.contains("mac")) {
+            captureCmdResult = saveScreenToFile("screencapture", "-C", filename);
+        } else if (os.contains("win")) {
+            throw new RuntimeException("Windows is not supported yet");
+        } else {
+            throw new RuntimeException(os + " is not supported");
+        }
+        if (captureCmdResult != 0) {
+            throw new RuntimeException("Failed to capture screen using native tool");
+        }
+        File imgFile = new File(filename);
+        BufferedImage img = getCroppedImageFromFile(area.asRectangle(), imgFile);
+        imgFile.delete();
+        return img;
+    }
+
+    /*
+     * Invoke native OS tool to save the screenshot to a file.
+     */
+    public static int saveScreenToFile (String... nativeToolCmd) {
+        ProcessBuilder processBuilder = new ProcessBuilder(nativeToolCmd);
+        processBuilder.redirectErrorStream(true);
+        int screenShotRun = 0;
+        String output = "";
+        try {
+            Process process = processBuilder.start();
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
+                output = reader.lines().collect(Collectors.joining(System.lineSeparator()));
+                screenShotRun = process.waitFor();
+            }
+        } catch (IOException | InterruptedException ex) {
+            if (screenShotRun == 0) screenShotRun = 255;
+            output += "Exception: " + ex;
+        }
+        if (screenShotRun != 0) {
+            log.error("Command run: {}%n Return code: {}%n Output/Error Message: {}%n",
+                    String.join(" ", nativeToolCmd), screenShotRun, output);
+        }
+        
+        return screenShotRun;
+    }
+
+    /*
+     * Load data from image file, crop it and return BufferedImage object
+     */
+    private static BufferedImage getCroppedImageFromFile(Rectangle cropRectangle, File imgFile) {
+        BufferedImage image;
+        try {
+            image = ImageIO.read(imgFile);
+        } catch (IOException e) {
+            throw new RuntimeException("Error reading image file " + imgFile.getName(), e);
+        }
+
+        if (cropRectangle != null) {
+            // Ensure the cropRectangle is within the bounds of the image
+            Rectangle bounds = new Rectangle(0, 0, image.getWidth(), image.getHeight());
+            Rectangle croppedRect = cropRectangle.intersection(bounds);
+
+            return image.getSubimage(croppedRect.x, croppedRect.y, croppedRect.width, croppedRect.height);
+        } else {
+            return image;
+        }
     }
 }

--- a/common/src/main/java/com/amazon/corretto/arctic/common/backend/impl/AwtRobotScreenRecorder.java
+++ b/common/src/main/java/com/amazon/corretto/arctic/common/backend/impl/AwtRobotScreenRecorder.java
@@ -137,10 +137,13 @@ public class AwtRobotScreenRecorder implements ArcticScreenRecorder {
         } else {
             throw new RuntimeException(os + "native capture is not supported");
         }
-        if (captureCmdResult != 0) {
+        File imgFile = new File(filename);
+        if (captureCmdResult != 0 || !imgFile.exists()) {
+            if(imgFile.exists()){
+                imgFile.delete();
+            }
             throw new RuntimeException("Failed to capture screen using native tool");
         }
-        File imgFile = new File(filename);
         BufferedImage img = getCroppedImageFromFile(area.asRectangle(), imgFile);
         imgFile.delete();
         return img;
@@ -149,7 +152,7 @@ public class AwtRobotScreenRecorder implements ArcticScreenRecorder {
     /*
      * Invoke native OS tool to save the screenshot to a file.
      */
-    public int saveScreenToFile (String... nativeToolCmd) {
+    private int saveScreenToFile (String... nativeToolCmd) {
         ProcessBuilder processBuilder = new ProcessBuilder(nativeToolCmd);
         processBuilder.redirectErrorStream(true);
         int screenShotRun = 0;

--- a/common/src/main/java/com/amazon/corretto/arctic/common/inject/ArcticCommonModule.java
+++ b/common/src/main/java/com/amazon/corretto/arctic/common/inject/ArcticCommonModule.java
@@ -56,6 +56,7 @@ public final class ArcticCommonModule extends ArcticModule {
     private void configureScreenCapture() {
         bindFromConfig(Integer.class, CommonInjectionKeys.SCREEN_CAPTURE_MARGIN_X, "any positive number");
         bindFromConfig(Integer.class, CommonInjectionKeys.SCREEN_CAPTURE_MARGIN_Y, "any positive number");
+        bindFromConfig(String.class, CommonInjectionKeys.NATIVE_CAPTURE_TOOL_LINUX, "only \'gnome-screenshot\'");
     }
 
     private void configureWorkbench() {

--- a/common/src/main/java/com/amazon/corretto/arctic/common/inject/CommonInjectionKeys.java
+++ b/common/src/main/java/com/amazon/corretto/arctic/common/inject/CommonInjectionKeys.java
@@ -34,6 +34,11 @@ public final class CommonInjectionKeys {
      */
     public static final String REPOSITORY_JSON_NAME = PREFIX + "repository.json.file";
 
+    /*
+     * Tool to use when using native screen capture.
+     */
+    public static final String NATIVE_CAPTURE_TOOL_LINUX = PREFIX + "backend.nativeCaptureTool.linux";
+
     public static final String SCOPE_MODE = PREFIX + "repository.scope.mode";
     public static final String REPOSITORY_SCOPE = PREFIX + "repository.scope";
     public static final String SCOPES = PREFIX + "repository.load.scopes";

--- a/common/src/main/java/com/amazon/corretto/arctic/common/model/event/ScreenshotCheck.java
+++ b/common/src/main/java/com/amazon/corretto/arctic/common/model/event/ScreenshotCheck.java
@@ -49,6 +49,11 @@ public final class ScreenshotCheck implements ArcticEvent {
     private Path filename;
 
     /**
+     * If present, represents that image should have a mouse cursor captured.
+     */
+    private boolean mouseCursor;
+
+    /**
      * If present, a List of alternative images that are acceptable for this screen check.
      */
     private Set<Path> alternativeImages = new HashSet<>();
@@ -102,5 +107,9 @@ public final class ScreenshotCheck implements ArcticEvent {
     @Override
     public SubType getSubType() {
         return SubType.SCREENSHOT_CHECK;
+    }
+
+    public boolean getMouseCursor() {
+        return mouseCursor;
     }
 }

--- a/player/src/main/java/com/amazon/corretto/arctic/player/backend/impl/ArcticImageCheckPlayer.java
+++ b/player/src/main/java/com/amazon/corretto/arctic/player/backend/impl/ArcticImageCheckPlayer.java
@@ -80,8 +80,7 @@ public final class ArcticImageCheckPlayer implements ArcticBackendPlayer {
         wbManager.position(saved.getWorkbench());
         shadeManager.position(saved.getShades());
         timeController.waitForScreen();
-        final ScreenshotCheck current = recorder.capture(saved.getSa());
-
+        final ScreenshotCheck current = recorder.capture(saved.getSa(), saved.getMouseCursor());
         return imgComparator.compare(current, saved, runningTestId, runningTestScope);
     }
 

--- a/player/src/main/java/com/amazon/corretto/arctic/player/preprocessing/impl/ScreenCheckValidatorPreProcessor.java
+++ b/player/src/main/java/com/amazon/corretto/arctic/player/preprocessing/impl/ScreenCheckValidatorPreProcessor.java
@@ -29,6 +29,7 @@ import com.amazon.corretto.arctic.player.inject.InjectionKeys;
 import com.amazon.corretto.arctic.player.model.ArcticRunningTest;
 import com.amazon.corretto.arctic.player.model.TestStatusCode;
 import com.amazon.corretto.arctic.player.preprocessing.ArcticPlayerPreProcessor;
+import com.amazon.corretto.arctic.common.model.event.ArcticEvent;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
 import org.slf4j.Logger;
@@ -93,7 +94,7 @@ public final class ScreenCheckValidatorPreProcessor implements ArcticPlayerPrePr
             timeController.waitFor(focusWait);
             focusManager.giveFocus(test.getRecording().getFocusPoint());
             timeController.waitFor(focusWait);
-            final ScreenshotCheck sc = screenRecorder.capture(test.getRecording().getInitialSc().getSa());
+            final ScreenshotCheck sc = screenRecorder.capture(test.getRecording().getInitialSc().getSa(),false);
             final boolean result = imageComparator.compare(sc, test.getRecording().getInitialSc(), test.getTestId(),
                     test.getRecording().getScope());
             if (!result && bypass) {

--- a/player/src/main/resources/player.properties
+++ b/player/src/main/resources/player.properties
@@ -82,6 +82,11 @@ arctic.common.session.default = arctic.session
 arctic.common.screen.capture.margin.x = 0
 arctic.common.screen.capture.margin.y = 0
 
+# Utility to use for native screen capture. Used when recording with native capture enabled in recorder.properties,
+# or during playback of recording taken with native capture enabled.
+# Current values: gnome-screenshot
+arctic.common.backend.nativeCaptureTool.linux = gnome-screenshot
+
 # Confirmation mode means arctic will wait for the finishedTest signal before running that test post-processing pipeline
 # instead of doing it after finished replaying events. In confirmation mode, non-confirmed tests are considered as not
 # passed.

--- a/recorder/src/main/java/com/amazon/corretto/arctic/recorder/backend/impl/ScreenCheckBackendRecorder.java
+++ b/recorder/src/main/java/com/amazon/corretto/arctic/recorder/backend/impl/ScreenCheckBackendRecorder.java
@@ -41,6 +41,10 @@ public class ScreenCheckBackendRecorder implements ArcticBackendRecorder {
         log.debug("ScreenCheckRecorder loaded");
         this.screenRecorder = screenRecorder;
         this.nativeCapture = nativeCapture;
+
+        if(this.nativeCapture){
+            validateNativeCaptureSupport();
+        }
     }
 
     @Override
@@ -60,5 +64,16 @@ public class ScreenCheckBackendRecorder implements ArcticBackendRecorder {
     @Override
     public String getName() {
         return NAME;
+    }
+
+    private void validateNativeCaptureSupport(){
+        String os = System.getProperty("os.name").toLowerCase();
+        if (!os.contains("linux")) {
+            throw new IllegalStateException(
+                "Native screen capture is only supported on Linux. " +
+                "Detected OS: " + System.getProperty("os.name") + ". " +
+                "Please disable 'arctic.recorder.backend.nativeCapture'"
+            );
+        }
     }
 }

--- a/recorder/src/main/java/com/amazon/corretto/arctic/recorder/backend/impl/ScreenCheckBackendRecorder.java
+++ b/recorder/src/main/java/com/amazon/corretto/arctic/recorder/backend/impl/ScreenCheckBackendRecorder.java
@@ -22,7 +22,9 @@ import com.amazon.corretto.arctic.common.backend.ArcticScreenRecorder;
 import com.amazon.corretto.arctic.common.model.event.ArcticEvent;
 import com.amazon.corretto.arctic.recorder.backend.ArcticBackendRecorder;
 import com.amazon.corretto.arctic.recorder.control.ArcticController;
+import com.amazon.corretto.arctic.recorder.inject.InjectionKeys;
 import jakarta.inject.Inject;
+import jakarta.inject.Named;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
@@ -30,13 +32,15 @@ import lombok.extern.slf4j.Slf4j;
 public class ScreenCheckBackendRecorder implements ArcticBackendRecorder {
     public static final String NAME = "sc";
     private final ArcticScreenRecorder screenRecorder;
+    private final boolean nativeCapture;
 
     @Getter private List<ArcticEvent> recordingBuffer;
 
     @Inject
-    public ScreenCheckBackendRecorder(final ArcticScreenRecorder screenRecorder) {
+    public ScreenCheckBackendRecorder(final ArcticScreenRecorder screenRecorder, @Named(InjectionKeys.BACKEND_NATIVE_CAPTURE) final boolean nativeCapture) {
         log.debug("ScreenCheckRecorder loaded");
         this.screenRecorder = screenRecorder;
+        this.nativeCapture = nativeCapture;
     }
 
     @Override
@@ -46,7 +50,12 @@ public class ScreenCheckBackendRecorder implements ArcticBackendRecorder {
                 recordingBuffer = new LinkedList<>();
                 break;
             case SCREEN_CHECK:
-                recordingBuffer.add(screenRecorder.capture());
+                if(this.nativeCapture){
+                    recordingBuffer.add(screenRecorder.capture(true));
+                }
+                else{
+                    recordingBuffer.add(screenRecorder.capture());
+                }
                 break;
             default:
                 break;

--- a/recorder/src/main/java/com/amazon/corretto/arctic/recorder/backend/impl/ScreenCheckBackendRecorder.java
+++ b/recorder/src/main/java/com/amazon/corretto/arctic/recorder/backend/impl/ScreenCheckBackendRecorder.java
@@ -50,12 +50,7 @@ public class ScreenCheckBackendRecorder implements ArcticBackendRecorder {
                 recordingBuffer = new LinkedList<>();
                 break;
             case SCREEN_CHECK:
-                if(this.nativeCapture){
-                    recordingBuffer.add(screenRecorder.capture(true));
-                }
-                else{
-                    recordingBuffer.add(screenRecorder.capture());
-                }
+                recordingBuffer.add(screenRecorder.capture(this.nativeCapture));
                 break;
             default:
                 break;

--- a/recorder/src/main/java/com/amazon/corretto/arctic/recorder/inject/ArcticBackendRecorderModule.java
+++ b/recorder/src/main/java/com/amazon/corretto/arctic/recorder/inject/ArcticBackendRecorderModule.java
@@ -66,7 +66,8 @@ public final class ArcticBackendRecorderModule extends ArcticModule {
             JnhMouseRecorder.NAME, ArcticBackendRecorderModule::registerJnhMouse,
             JnhMouseMoveRecorder.NAME, ArcticBackendRecorderModule::registerJnhMouseMove,
             JnhMouseWheelRecorder.NAME, ArcticBackendRecorderModule::registerJnhMouseWheel,
-            JnhKeyboardRecorder.NAME, ArcticBackendRecorderModule::registerJnhKeyboard);
+            JnhKeyboardRecorder.NAME, ArcticBackendRecorderModule::registerJnhKeyboard,
+            ScreenCheckBackendRecorder.NAME, ArcticBackendRecorderModule::registerNativeCapture);
 
     /**
      * Constructor for the module.
@@ -119,5 +120,9 @@ public final class ArcticBackendRecorderModule extends ArcticModule {
 
     private void registerJnhKeyboard() {
         bind(new TypeLiteral<Function<NativeKeyEvent, KeyboardEvent>>(){}).to(JnhNativeKeyEvent2ArcticEvent.class);
+    }
+
+    private void registerNativeCapture() {
+        bindFromConfig(Boolean.class, InjectionKeys.BACKEND_NATIVE_CAPTURE, List.of(true, false));
     }
 }

--- a/recorder/src/main/java/com/amazon/corretto/arctic/recorder/inject/InjectionKeys.java
+++ b/recorder/src/main/java/com/amazon/corretto/arctic/recorder/inject/InjectionKeys.java
@@ -26,6 +26,7 @@ public class InjectionKeys {
 
     public static final String BACKEND_RECORDERS = PREFIX + "backend.recorders";
     public static final String BACKEND_RECORDING_MODE = PREFIX + "backend.recordingMode";
+    public static final String BACKEND_NATIVE_CAPTURE = PREFIX + "backend.nativeCapture";
     public static final String OFFSET_PROVIDER = PREFIX + "offset.provider";
     public static final String OFFSET_FIXED_X = PREFIX + "offset.fixed.x";
     public static final String OFFSET_AWT_EXTRA = PREFIX + "offset.awt.extra";

--- a/recorder/src/main/java/com/amazon/corretto/arctic/recorder/preprocessing/impl/FirstScCheckPreProcessor.java
+++ b/recorder/src/main/java/com/amazon/corretto/arctic/recorder/preprocessing/impl/FirstScCheckPreProcessor.java
@@ -20,6 +20,7 @@ import com.amazon.corretto.arctic.api.exception.ArcticException;
 import com.amazon.corretto.arctic.common.backend.ArcticScreenRecorder;
 import com.amazon.corretto.arctic.common.gui.WorkbenchManager;
 import com.amazon.corretto.arctic.common.model.ArcticTest;
+import com.amazon.corretto.arctic.common.model.event.ArcticEvent;
 import com.amazon.corretto.arctic.common.model.event.ScreenshotCheck;
 import com.amazon.corretto.arctic.common.model.gui.ScreenArea;
 import com.amazon.corretto.arctic.recorder.inject.InjectionKeys;
@@ -57,7 +58,7 @@ public final class FirstScCheckPreProcessor implements ArcticRecorderPreProcesso
         final ScreenArea wbArea = wbManager.getScreenArea();
         final int matchHeight = test.getFocusPoint().getY() - wbArea.getY() + matchSize;
         final ScreenArea sa = new ScreenArea(wbArea.getX(), wbArea.getY(), wbArea.getW(), matchHeight);
-        final ScreenshotCheck sc = screenRecorder.capture(sa);
+        final ScreenshotCheck sc = screenRecorder.capture(sa, false);
         test.setInitialSc(sc);
         sc.setTimestamp(0);
         return true;

--- a/recorder/src/main/resources/recorder.properties
+++ b/recorder/src/main/resources/recorder.properties
@@ -84,6 +84,9 @@ arctic.recorder.backend.recorders = jnhMouse, jnhMouseWheel, jnhMouseMove, jnhKe
 # Defines which events we want during the recorder. Check ArcticEvent.java for values.
 arctic.recorder.backend.recordingMode = 0x13F07
 
+# Use native screen capture utility, e.g. for capturing mouse cursor
+arctic.recorder.backend.nativeCapture = false
+
 # Defines which provider to use when calculating the position of the test window. The distance between the workbench Y
 # position and the test Y position is the offset. It doesn't need to be exact, but this point will be used to click
 # whenever we need to give focus to the test window.

--- a/recorder/src/main/resources/recorder.properties
+++ b/recorder/src/main/resources/recorder.properties
@@ -72,6 +72,11 @@ arctic.common.session.default = arctic.session
 arctic.common.screen.capture.margin.x = 0
 arctic.common.screen.capture.margin.y = 0
 
+# Utility to use for native screen capture. Used when recording with native capture enabled in recorder.properties,
+# or during playback of recording taken with native capture enabled.
+# Current values: gnome-screenshot
+arctic.common.backend.nativeCaptureTool.linux = gnome-screenshot
+
 # Define which backends we are going to use to record
 # Values can be:
 #   jnhMouse: Records Mouse press, release and click events.
@@ -84,7 +89,7 @@ arctic.recorder.backend.recorders = jnhMouse, jnhMouseWheel, jnhMouseMove, jnhKe
 # Defines which events we want during the recorder. Check ArcticEvent.java for values.
 arctic.recorder.backend.recordingMode = 0x13F07
 
-# Use native screen capture utility, e.g. for capturing mouse cursor
+# Use native screen capture utility for capturing mouse cursor
 arctic.recorder.backend.nativeCapture = false
 
 # Defines which provider to use when calculating the position of the test window. The distance between the workbench Y


### PR DESCRIPTION
Thank you for taking the time to help improve arctic.

If your pull request concerns a security vulnerability then please do not file it.
Instead, report the problem by email to aws-security@amazon.com.
(You can find more information regarding security issues at https://aws.amazon.com/security/vulnerability-reporting/.)

### Description
Adds a new boolean property in `recorder.properties`: “`arctic.recorder.backend.nativeCapture`”. When set to true, recordings will use a native utility to generate the screen capture and crop it to the workplace area. Currently only gnome-screenshot for linux is used but others can be added in the future for other platforms. When the player compares against screenshots taken with native capture, the player will also use native capture.

### Related issues
N/A

### Motivation and context
Arctic relies on `awt.Robot.createScreenCapture()` for taking screenshots. However, this method does not capture the mouse cursor, which may be required for validating some tests. 

### How has this been tested?
Recorded and replayed some basic tests with `arctic.recorder.backend.nativeCapture = true`, they passed successfully. Verified the screenshots in new recordings contain mouse cursor. Also ran past recordings from before these changes, they are unaffected.

### Platform information
    Works on OS: Linux only
    Applies to version 0.8.1

### Additional context

Much of the logic is appended to the AwtRobotScreenRecorder, rather then creating a new class inheriting from ArcticScreenRecorder. This is because the implementation of ArcticScreenRecorder is injected on startup, so validating cursor tests would require a separate arctic run after adjusting the properties. Would appreciate feedback on if this approach is preferred.

### Contribution confirmation

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

